### PR TITLE
add -K option to indent continuations lines starting with ampersand

### DIFF
--- a/findent/src/flags.cpp
+++ b/findent/src/flags.cpp
@@ -205,6 +205,9 @@ int Flags::get_flags(int argc, char *argv[])
       {"align_paren"        , optional_argument, 0, DO_ALIGN_PAREN       },
       {"align-paren"        , optional_argument, 0, DO_ALIGN_PAREN       },
 
+      {"indent-ampersand"   , required_argument, 0, 'K'                  },
+      {"indent_ampersand"   , required_argument, 0, 'K'                  },
+
       {"last_indent"        , no_argument      , 0, DO_LAST_INDENT       },
       {"last-indent"        , no_argument      , 0, DO_LAST_INDENT       },
 
@@ -326,7 +329,7 @@ int Flags::get_flags(int argc, char *argv[])
       "`~!@#$%^&*()-_=+[{]};:'\"|,<.>/?";
 
    while((c=getopt_long(nflags,allflags,
-	       "a:b:c:C:d:e:E:f:F:hHi:I:j:k:l:L:m:M:o:qQr:R:s:t:vw:x:",
+	       "a:b:c:C:d:e:E:f:F:hHi:I:j:k:Kl:L:m:M:o:qQr:R:s:t:vw:x:",
 	       longopts, &option_index))!=-1)
    {
       switch(c)
@@ -417,6 +420,10 @@ int Flags::get_flags(int argc, char *argv[])
 	    else
 	       cont_indent = atoi(optarg);
 	    break;
+     case 'K': // --indent_ampersand
+        if (end_env_found)
+           indent_ampersand = 1;
+        break;
 	 case 'l' :
 	    optargcheck;
 	    if(std::string(optarg) == "astindent")       // --last_indent

--- a/findent/src/flags.h
+++ b/findent/src/flags.h
@@ -90,6 +90,7 @@ class Flags
    bool include_left         ; // 1: put include on the start of the line
    bool include_left_default ;
    bool indent_continuation  ;
+   bool indent_ampersand     ; // indent continuation lines starting with ampersand, too
    bool indent_contain       ;
    bool input_format_gnu     ;
    bool label_left           ; // 1: put statement labels on the start of the line

--- a/findent/src/free.cpp
+++ b/findent/src/free.cpp
@@ -405,7 +405,10 @@ void Free::output(lines_t &lines, bool contains_hollerith, lines_t *fixedlines)
 	 int l;
 	 if(to_mycout)
 	 {
-	    l = M(std::max(cur_indent,0));
+        if (fi->flags.indent_ampersand && prev_expect_continuation)
+           l = M(std::max(cur_indent + fi->flags.cont_indent, 0));
+        else
+           l = M(std::max(cur_indent, 0));
 	    //mycout << insert_omp(blanks(M(std::max(cur_indent,0))),ompstr) <<
 	    //  lines.front().trim() << endline;
 	    std::string lineout = insert_omp(blanks(l),ompstr) + lines.front().trim();


### PR DESCRIPTION
This adds a new option `-K`, which will indent continuation lines that start with `&` just like the ones that do not. While arguably not that pretty, this is useful to match the default emacs indent behavior. If this is an acceptable feature to be included, I can add some documentation.